### PR TITLE
Enables Support in Gnome Shell 3.12, 3.14, 3.16 and 3.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,14 @@ active workspace are listed first. Clicking on a menu item restores the window a
 to the workspace it is on.
 
 ![screenshot](https://github.com/cboehme/minimized-windows-list/raw/master/screenshot.png)
+
+Install Instructions
+======================
+
+```
+git clone git@github.com:ElectricPrism/minimized-windows-list.git
+```
+
+```
+mv minimized-windows-list ~/.local/share/gnome-shell/extensions/MinimizedWindowsList@b3e.net
+```

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/bash
-
-FILES="extension.js metadata.json LICENSE"
-
-zip -j minimized-windows-list.zip $FILES

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,13 @@
 	"uuid": "MinimizedWindowsList@b3e.net", 
 	"name": "Minimized Windows List",
 	"description": "Adds an icon to the top bar showing a list of minimized windows",
-	"url": "http://github.com/cboehme/minimized-windows-list",
-	"shell-version": ["3.10"], 
-	"version": 5
+	"url": "https://github.com/cboehme/minimized-windows-list",
+	"shell-version": [
+		"3.10",
+		"3.12",
+		"3.14",
+		"3.16",
+		"3.18"
+	],
+	"version": 6
 }


### PR DESCRIPTION
Everything seems to be working in 3.18, please update the GIT Clone URL on the additions to README.md if accepted.
